### PR TITLE
Add dynamic method handling in WrappedEngine

### DIFF
--- a/src/WrappedEngine.php
+++ b/src/WrappedEngine.php
@@ -41,4 +41,16 @@ class WrappedEngine implements Engine
         $starting = $opening ? 'Starting' : 'Ending';
         return '<!-- ' . $starting . ' ' . $path . ' -->';
     }
+
+    /**
+     * Handle dynamic method calls into the engine instance.
+     *
+     * @param  string  $method
+     * @param  array<mixed>  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->engine->$method(...$parameters);
+    }
 }


### PR DESCRIPTION
Define el método mágico `__call` en la clase `WrappedEngine`. Este método permite manejar llamadas a métodos que no existen explícitamente en la clase `WrappedEngine` pero que pueden existir en la instancia de `Engine` que se está envolviendo. 

Cuando se llama a un método que no está definido en `WrappedEngine`, el método `__call` intercepta la llamada y la redirige al objeto `engine` subyacente, pasando los parámetros originales.